### PR TITLE
Fix: Resolve duplicate 'path' declaration causing server crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.static('public')); // Configure Express to serve static files
 
-const path = require('path');
-
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });


### PR DESCRIPTION
This PR fixes the  that was causing the server to crash.\n\n---\n**Fix Description:**\n\n*   Removed the redundant  declaration in .\n\nThis resolves the exception and allows the server to start correctly.\n\n(Automated bug fix. Please review and merge.)