### PR TITLE
Feat: Update Homepage Copy with Professional Profile

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Personal website of Alexandru Lucian, a platform for projects and contact.">
-    <title>Alexandru Lucian - Home</title>
+    <meta name="description" content="Personal portfolio of Alexandru-Lucian Francu, Senior Java Developer and Solution Architect.">
+    <title>Alexandru-Lucian Francu - Home</title>
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
     <header>
-        <h1>Welcome to My Personal Website</h1>
+        <div class="container">
+            <h1>Alexandru-Lucian Francu</h1>
+            <p>Senior Java Developer | Solution Architect</p>
+        </div>
     </header>
     <nav>
         <a href="/" class="active">Home</a>
@@ -18,12 +21,17 @@
         <a href="/contact">Contact</a>
     </nav>
     <main>
-        <p>This is the main landing page for my personal website.</p>
-        <p>Work in progress, powered by OpenClaw & Express.js!</p>
+        <section class="hero">
+            <div class="container">
+                <h2>Professional Profile</h2>
+                <p>Welcome! I am a Senior Java Developer and Solution Architect with over 10 years of experience in building scalable backend systems, integrating complex financial APIs, and leading technical migrations. Currently, I am focused on expanding my expertise in Machine Learning and AI to build next-generation intelligent applications.</p>
+                <p>Explore my work, professional journey, or get in touch!</p>
+            </div>
+        </section>
     </main>
     <footer>
         <div class="container">
-            <p>&copy; 2026 Alexandru Lucian | <a href="https://github.com/AlexandruLucian" target="_blank" rel="noopener noreferrer">GitHub</a> | <a href="https://www.linkedin.com/in/alexandru-lucian-francu/" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
+            <p>&copy; 2026 Alexandru-Lucian Francu | <a href="https://github.com/AlexandruLucian" target="_blank" rel="noopener noreferrer">GitHub</a> | <a href="https://www.linkedin.com/in/alexandru-lucian-francu/" target="_blank" rel="noopener noreferrer">LinkedIn</a></p>
         </div>
     </footer>
 </body>


### PR DESCRIPTION
This PR addresses issue #26: Update Homepage Copy with Professional Profile\n\n- Updated index.html with Alexandru-Lucian Francu's professional summary.\n- Set title to 'Alexandru-Lucian Francu - Home'.\n- Added hero section with 10+ years backend experience and AI focus.\n\nCloses #26